### PR TITLE
Implement Lumino lifecycle events with native elements.

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -18,12 +18,13 @@
 import { WidgetModel, WidgetView, IClassicComm } from '@jupyter-widgets/base';
 import * as base from '@jupyter-widgets/base';
 import * as controls from '@jupyter-widgets/controls';
-import {ManagerBase} from '@jupyter-widgets/base-manager';
+import { ManagerBase } from '@jupyter-widgets/base-manager';
 import { JSONObject } from '@lumino/coreutils';
-import {Loader} from './amd';
-import { IComm, IWidgetManager, WidgetEnvironment } from './api';
-import {swizzle} from './swizzle';
 import { Widget } from '@lumino/widgets';
+
+import { Loader } from './amd';
+import { IComm, IWidgetManager, WidgetEnvironment } from './api';
+import { swizzle } from './swizzle';
 
 export class Manager extends ManagerBase implements IWidgetManager {
   private readonly models = new Map<string, Promise<WidgetModel>>();


### PR DESCRIPTION
This fixes the after-attach event to occur when the element is added to
a live DOM tree, fixing
https://github.com/googlecolab/colab-cdn-widget-manager/issues/1.