### PR TITLE
Support output widgets.

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -60,6 +60,9 @@ export declare interface WidgetEnvironment {
     data?: unknown,
     buffers?: ArrayBuffer[]
   ): Promise<IComm>;
+
+  /** Renders a standard Jupyter output item into destination.  */
+  renderOutput(outputItem: unknown, destination: Element): Promise<void>;
 }
 
 export declare interface IWidgetManager {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -16,6 +16,7 @@
  */
 import {Loader} from './amd';
 import {IComm, IWidgetManager, WidgetEnvironment} from './api';
+import * as outputs from './outputs';
 import {swizzle} from './swizzle';
 import {WidgetModel, WidgetView, IClassicComm} from '@jupyter-widgets/base';
 import * as base from '@jupyter-widgets/base';
@@ -78,6 +79,8 @@ export class Manager extends ManagerBase implements IWidgetManager {
       }
       return module;
     });
+
+    this.loader.define('@jupyter-widgets/output', [], () => outputs);
   }
 
   protected async loadClass(
@@ -165,6 +168,10 @@ export class Manager extends ManagerBase implements IWidgetManager {
     const lifecycleAdapter = new LuminoLifecycleAdapter(view.luminoWidget);
     lifecycleAdapter.appendChild(view.el);
     container.appendChild(lifecycleAdapter);
+  }
+
+  renderOutput(outputItem: unknown, destination: Element): Promise<void> {
+    return this.environment.renderOutput(outputItem, destination);
   }
 }
 

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -36,9 +36,10 @@ export class OutputView extends DOMWidgetView {
    */
   /* eslint @typescript-eslint/no-explicit-any: "off" */
   render(): any {
-    super.render();
+    const result = super.render();
     this.listenTo(this.model, 'change:outputs', this.updateOutputs);
     this.updateOutputs();
+    return result;
   }
 
   private async updateOutputs() {

--- a/test/manager.spec.js
+++ b/test/manager.spec.js
@@ -34,6 +34,12 @@ class FakeState {
       state: state.state,
     };
   }
+
+  async renderOutput(output, element) {
+    if (output.data['text/html']) {
+      element.innerHTML = output.data['text/html'];
+    }
+  }
 }
 
 describe('widget manager', () => {
@@ -140,5 +146,17 @@ describe('widget manager', () => {
     document.body.appendChild(container);
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(view.hasBeenDisplayed).toBe(true);
+  });
+
+  it('supports output widgets', async () => {
+    const modelId = '99837b7c37654c8c8f35cad63aaad130';
+    const state = await (await fetch('/base/test/output_state.json')).json();
+
+    const provider = new FakeState(state);
+    const manager = createWidgetManager(provider);
+
+    await manager.render(modelId, container);
+    const marquee = container.querySelector('marquee');
+    expect(marquee).toBeInstanceOf(HTMLElement);
   });
 });

--- a/test/output_state.json
+++ b/test/output_state.json
@@ -1,0 +1,81 @@
+{
+  "99837b7c37654c8c8f35cad63aaad130": {
+    "model_module": "@jupyter-widgets/output",
+    "model_name": "OutputModel",
+    "model_module_version": "1.0.0",
+    "state": {
+      "_view_name": "OutputView",
+      "msg_id": "",
+      "_dom_classes": [],
+      "_model_name": "OutputModel",
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/html": "<marquee>Hello</marquee>",
+            "text/plain": "<IPython.core.display.HTML object>"
+          },
+          "metadata": {}
+        }
+      ],
+      "_view_module": "@jupyter-widgets/output",
+      "_model_module_version": "1.0.0",
+      "_view_count": null,
+      "_view_module_version": "1.0.0",
+      "layout": "IPY_MODEL_f6650a8a02f544a68a20055976b8b0aa",
+      "_model_module": "@jupyter-widgets/output"
+    }
+  },
+  "f6650a8a02f544a68a20055976b8b0aa": {
+    "model_module": "@jupyter-widgets/base",
+    "model_name": "LayoutModel",
+    "model_module_version": "1.2.0",
+    "state": {
+      "_view_name": "LayoutView",
+      "grid_template_rows": null,
+      "right": null,
+      "justify_content": null,
+      "_view_module": "@jupyter-widgets/base",
+      "overflow": null,
+      "_model_module_version": "1.2.0",
+      "_view_count": null,
+      "flex_flow": null,
+      "width": null,
+      "min_width": null,
+      "border": "1px solid black",
+      "align_items": null,
+      "bottom": null,
+      "_model_module": "@jupyter-widgets/base",
+      "top": null,
+      "grid_column": null,
+      "overflow_y": null,
+      "overflow_x": null,
+      "grid_auto_flow": null,
+      "grid_area": null,
+      "grid_template_columns": null,
+      "flex": null,
+      "_model_name": "LayoutModel",
+      "justify_items": null,
+      "grid_row": null,
+      "max_height": null,
+      "align_content": null,
+      "visibility": null,
+      "align_self": null,
+      "height": null,
+      "min_height": null,
+      "padding": null,
+      "grid_auto_rows": null,
+      "grid_gap": null,
+      "max_width": null,
+      "order": null,
+      "_view_module_version": "1.2.0",
+      "grid_template_areas": null,
+      "object_position": null,
+      "object_fit": null,
+      "grid_auto_columns": null,
+      "margin": null,
+      "display": null,
+      "left": null
+    }
+  }
+}


### PR DESCRIPTION
The default implementation is essentially a placeholder. This adds a concrete implementation with support from the generalized hosting API.

The implementation is based on https://github.com/googlecolab/colab-widgets/blob/master/src/outputs.ts.

Addresses https://github.com/googlecolab/colab-cdn-widget-manager/issues/4.