### PR TITLE
Clean comm messages before sending.

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -212,6 +212,10 @@ class ClassicComm implements IClassicComm {
       });
       opts = {buffers: sendBuffers};
     }
+    // Round-trip through JSON to drop non-transferrable properties. These will
+    // throw errors when sent via a message channel, vs JSON.stringify which
+    // will just skip.
+    data = JSON.parse(JSON.stringify(data));
     this.comm.send(data, opts).then(() => {
       if (callbacks && callbacks.iopub && callbacks.iopub.status) {
         callbacks.iopub.status({


### PR DESCRIPTION
Fix for https://github.com/googlecolab/colab-cdn-widget-manager/issues/10

Appears that some libraries may send comm messages with non-transferrable properties, relying on JSON serialization to omit those properties. These messages will throw when sent over an API which requires transferrables, such as a MessageChannel.

This just round-trips messages through JSON.stringify/JSON.parse to omit non-transferrables.