### PR TITLE
Add support for nglviewer and fix leaflet.

### DIFF
--- a/src/amd.ts
+++ b/src/amd.ts
@@ -33,7 +33,7 @@ export class Loader {
       this.register();
 
       const url = this.resolveModule(moduleName, moduleVersion);
-      const script = await (await fetch(url.toString())).text();
+      const script = await (await fetch(url.toString())).text() + `\n//@ sourceURL=${url}`;
       const fn = new Function('define', script);
       let module: Module | undefined;
       const define = (

--- a/src/amd.ts
+++ b/src/amd.ts
@@ -33,7 +33,8 @@ export class Loader {
       this.register();
 
       const url = this.resolveModule(moduleName, moduleVersion);
-      const script = await (await fetch(url.toString())).text() + `\n//@ sourceURL=${url}`;
+      const script =
+        (await (await fetch(url.toString())).text()) + `\n//@ sourceURL=${url}`;
       const fn = new Function('define', script);
       let module: Module | undefined;
       const define = (

--- a/src/index.css
+++ b/src/index.css
@@ -9,3 +9,7 @@
   --jp-ui-font-color1: var(--colab-primary-text-color);
   --jp-widgets-input-background-color: var(--colab-secondary-surface-color);
 }
+
+colab-lumino-adapter {
+  display: block;
+}

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -18,7 +18,12 @@ import {Loader} from './amd';
 import {IComm, IWidgetManager, WidgetEnvironment} from './api';
 import * as outputs from './outputs';
 import {swizzle} from './swizzle';
-import {WidgetModel, WidgetView, IClassicComm, DOMWidgetView} from '@jupyter-widgets/base';
+import {
+  WidgetModel,
+  WidgetView,
+  IClassicComm,
+  DOMWidgetView,
+} from '@jupyter-widgets/base';
 import * as base from '@jupyter-widgets/base';
 import {ManagerBase} from '@jupyter-widgets/base-manager';
 import * as controls from '@jupyter-widgets/controls';
@@ -50,11 +55,15 @@ export class Manager extends ManagerBase implements IWidgetManager {
     };
     base.WidgetModel.extend = controls.ButtonModel.extend = extend;
 
-    Object.defineProperty(DOMWidgetView.prototype, 'pWidget', {
-      get: function () {
-        return this.luminoWidget;
-      }
-    });
+    // https://github.com/googlecolab/colab-cdn-widget-manager/issues/12
+    // Add pWidget for better compat with jupyter-widgets 4.0.0.
+    if (!Object.getOwnPropertyDescriptor(DOMWidgetView.prototype, 'pWidget')) {
+      Object.defineProperty(DOMWidgetView.prototype, 'pWidget', {
+        get: function () {
+          return this.luminoWidget;
+        },
+      });
+    }
 
     this.loader.define('@jupyter-widgets/base', [], () => {
       const module: {[key: string]: unknown} = {};

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -18,7 +18,7 @@ import {Loader} from './amd';
 import {IComm, IWidgetManager, WidgetEnvironment} from './api';
 import * as outputs from './outputs';
 import {swizzle} from './swizzle';
-import {WidgetModel, WidgetView, IClassicComm} from '@jupyter-widgets/base';
+import {WidgetModel, WidgetView, IClassicComm, DOMWidgetView} from '@jupyter-widgets/base';
 import * as base from '@jupyter-widgets/base';
 import {ManagerBase} from '@jupyter-widgets/base-manager';
 import * as controls from '@jupyter-widgets/controls';
@@ -49,6 +49,12 @@ export class Manager extends ManagerBase implements IWidgetManager {
       return result;
     };
     base.WidgetModel.extend = controls.ButtonModel.extend = extend;
+
+    Object.defineProperty(DOMWidgetView.prototype, 'pWidget', {
+      get: function () {
+        return this.luminoWidget;
+      }
+    });
 
     this.loader.define('@jupyter-widgets/base', [], () => {
       const module: {[key: string]: unknown} = {};
@@ -241,7 +247,7 @@ class ClassicComm implements IClassicComm {
   on_msg(callback: (x: unknown) => void) {
     (async () => {
       for await (const message of this.comm.messages) {
-        let buffers;
+        let buffers: Uint8Array[] = [];
         if (message.buffers) {
           // The comm callback is typed as ArrayBuffer|ArrayBufferView but
           // some code (pythreejs) require ArrayBufferViews.


### PR DESCRIPTION
A couple of tweaks to fix nglviewer and fix leaflet:
 - nglviewer expects the binary buffers to always be set (an empty array as opposed to undefined). For https://github.com/googlecolab/colab-cdn-widget-manager/issues/13.
 - nglviewer uses jQuery UI's `ui.resizable` extension which needs the root element to have width when initially created. Changed the root element to `block` styling to fix this. For https://github.com/googlecolab/colab-cdn-widget-manager/issues/13.
 - Added a placeholder shim for pWidget to improve compatibility with jupyter-widgets 4.0.0 until we get more complete support (or until 5.0 goes stable). Fix for https://github.com/googlecolab/colab-cdn-widget-manager/issues/12.
![image](https://user-images.githubusercontent.com/2152569/134750379-0799518b-1e21-411b-aa8d-e9bdbeacb171.png)
