### PR TITLE
Normalize model state before passing to widget manager.

### DIFF
--- a/test/server/server.ts
+++ b/test/server/server.ts
@@ -62,6 +62,9 @@ async function serveTest(request: IncomingMessage, response: ServerResponse) {
     case '.html':
       contentType = 'text/html';
       break;
+    case '.js':
+      contentType = 'text/javascript';
+      break;
   }
   response.writeHead(200, {
     'Content-Type': contentType,


### PR DESCRIPTION
bqplot expects binary data in the state to be a DataView object, Colab was passing it as an ArrayBuffer. The API specifies that it can be either (https://github.com/jupyter-widgets/ipywidgets/blob/3558ce6a22b4a6b1badb69f0507a6ac5b245a17f/packages/base/src/utils.ts#L147-L148).

This uses the widgets remove/put methods to standardize the buffer format.