### PR TITLE
Target 6.0.0 stable version of widgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1451,326 +1451,276 @@
       }
     },
     "@jupyter-widgets/base": {
-      "version": "5.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-5.0.0-alpha.3.tgz",
-      "integrity": "sha512-x4NQA6LydWgintI2xF2qKx9rdqyDRm3t7NXATX6reQfTfiRY9jzTWGN188PtAt80SXLHjCFK4RiIm8SXY9Ip8Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-6.0.0.tgz",
+      "integrity": "sha512-UntW6jBZtj4lrpgdUhd0QRPn13Ce8YeFVcSCp0dpTqjVwtz3ySn9OUiI++1iboDqzSGZ01w/y2HMj8HhqRVQSg==",
       "dev": true,
       "requires": {
         "@jupyterlab/services": "^6.0.0",
-        "@lumino/coreutils": "^1.2.0",
-        "@lumino/messaging": "^1.2.1",
-        "@lumino/widgets": "^1.3.0",
-        "@types/backbone": "1.4.10",
+        "@lumino/coreutils": "^1.11.1",
+        "@lumino/messaging": "^1.10.1",
+        "@lumino/widgets": "^1.30.0",
+        "@types/backbone": "1.4.14",
         "@types/lodash": "^4.14.134",
         "backbone": "1.4.0",
         "jquery": "^3.1.1",
         "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "@types/backbone": {
-          "version": "1.4.10",
-          "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.10.tgz",
-          "integrity": "sha512-X6UM8N9i4WFtO1F53Z3DE7mjI7UxEfxyFtMTYHOPFhYFvExDuu0UJENstnA023+/FnVOdxltMIKc4picZxW4dA==",
-          "dev": true,
-          "requires": {
-            "@types/jquery": "*",
-            "@types/underscore": "*"
-          }
-        },
-        "backbone": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-          "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-          "dev": true,
-          "requires": {
-            "underscore": ">=1.8.3"
-          }
-        }
       }
     },
     "@jupyter-widgets/base-manager": {
-      "version": "1.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@jupyter-widgets/base-manager/-/base-manager-1.0.0-alpha.2.tgz",
-      "integrity": "sha512-d5lCQmVaI/oad2VLW7RZ792ecfFTkSdMRJkko7w2tHwUN/h9ytiU58ngET2dyGHB6Q1fDW1vMM67XDdVcKdZ0Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/base-manager/-/base-manager-1.0.1.tgz",
+      "integrity": "sha512-3y7RueXBDWhPz9Hp9f3DUIkpYO4Jb3k/51USdGqaQvbn85ux7c8pV3U6oEfm55i4fkGHMHRaRtmkn6SujM2u3Q==",
       "dev": true,
       "requires": {
-        "@jupyter-widgets/base": "^5.0.0-alpha.2",
+        "@jupyter-widgets/base": "^6.0.0",
         "@jupyterlab/services": "^6.0.0",
-        "@lumino/coreutils": "^1.4.2",
-        "base64-js": "^1.2.1"
-      },
-      "dependencies": {
-        "@jupyter-widgets/base": {
-          "version": "5.0.0-alpha.3",
-          "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-5.0.0-alpha.3.tgz",
-          "integrity": "sha512-x4NQA6LydWgintI2xF2qKx9rdqyDRm3t7NXATX6reQfTfiRY9jzTWGN188PtAt80SXLHjCFK4RiIm8SXY9Ip8Q==",
-          "dev": true,
-          "requires": {
-            "@jupyterlab/services": "^6.0.0",
-            "@lumino/coreutils": "^1.2.0",
-            "@lumino/messaging": "^1.2.1",
-            "@lumino/widgets": "^1.3.0",
-            "@types/backbone": "1.4.10",
-            "@types/lodash": "^4.14.134",
-            "backbone": "1.4.0",
-            "jquery": "^3.1.1",
-            "lodash": "^4.17.4"
-          }
-        },
-        "@types/backbone": {
-          "version": "1.4.10",
-          "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.10.tgz",
-          "integrity": "sha512-X6UM8N9i4WFtO1F53Z3DE7mjI7UxEfxyFtMTYHOPFhYFvExDuu0UJENstnA023+/FnVOdxltMIKc4picZxW4dA==",
-          "dev": true,
-          "requires": {
-            "@types/jquery": "*",
-            "@types/underscore": "*"
-          }
-        },
-        "backbone": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-          "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-          "dev": true,
-          "requires": {
-            "underscore": ">=1.8.3"
-          }
-        }
+        "@lumino/coreutils": "^1.11.1",
+        "base64-js": "^1.2.1",
+        "sanitize-html": "^2.3"
       }
     },
     "@jupyter-widgets/controls": {
-      "version": "4.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@jupyter-widgets/controls/-/controls-4.0.0-alpha.3.tgz",
-      "integrity": "sha512-DrvUs2iHA1rGSnkQFBH3uOTEGu6/NHxrAd8lO46sgueNEqGgnLrAlpE/UqJDAHwriCnH/I0J0KCq2PqbDZYJ+g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/controls/-/controls-5.0.0.tgz",
+      "integrity": "sha512-aFu2DF2EbJ9LxIAOqd8CCmOlQzkZRMyvksZBhSnHn6zJwnxrxBMarzvZeHR4edSXhQnaO1gFxJzwox0P2BobVw==",
       "dev": true,
       "requires": {
-        "@jupyter-widgets/base": "^5.0.0-alpha.3",
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/domutils": "^1.1.7",
-        "@lumino/messaging": "^1.3.3",
-        "@lumino/signaling": "^1.3.5",
-        "@lumino/widgets": "^1.11.1",
+        "@jupyter-widgets/base": "^6.0.0",
+        "@lumino/algorithm": "^1.9.1",
+        "@lumino/domutils": "^1.8.1",
+        "@lumino/messaging": "^1.10.1",
+        "@lumino/signaling": "^1.10.1",
+        "@lumino/widgets": "^1.30.0",
         "d3-color": "^3.0.1",
         "d3-format": "^3.0.1",
         "jquery": "^3.1.1",
-        "nouislider": "15.2.0"
+        "nouislider": "15.4.0"
       }
     },
     "@jupyterlab/coreutils": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.0.3.tgz",
-      "integrity": "sha512-PfdtV95/nSEwYjkaZltCTgumT22BekpSaPXF9oWtrCxC2Gc6zP8BxPhMdbPbx67y6FeO8vltr6dxOat93wZ4KA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-5.4.5.tgz",
+      "integrity": "sha512-nS7h0ABc8mbfhNg/1rOpNQZ6lR/UW8+Ehj4IOiod9RFnk+CiH+qlC8r4bBHhjoApnXW/6lxUbQnrBh5V2kjsMQ==",
       "dev": true,
       "requires": {
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
         "minimist": "~1.2.0",
         "moment": "^2.24.0",
         "path-browserify": "^1.0.0",
-        "url-parse": "~1.4.7"
+        "url-parse": "~1.5.1"
       }
     },
     "@jupyterlab/nbformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.0.3.tgz",
-      "integrity": "sha512-o7UMbRXQCGjHOoXhclov6JP/xSwFkx2Bv2qZldU5Yey+3RIcSFlnI8OcPHVZWmz+9xzdtXEmEhVnbErESO1fsg==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-3.4.5.tgz",
+      "integrity": "sha512-35AHfuqw1vElV6WAmE6XTe8ehpOQ6n6YOz2BxXqNkERMm8mUJjAO8Wbo7cssaFavF6T+FxNogoAI08DAel1S3Q==",
       "dev": true,
       "requires": {
-        "@lumino/coreutils": "^1.5.3"
+        "@lumino/coreutils": "^1.11.0"
       }
     },
     "@jupyterlab/observables": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.0.3.tgz",
-      "integrity": "sha512-OrAO201PkaFRJ+hWQB5Ozasnp/TkafMC/hOYcThWEQ9SFZEyanmTJIJh0hiHBmWmCorH2ocgTrp0csCzqVXc5w==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-4.4.5.tgz",
+      "integrity": "sha512-FjSsWnwPAxbqQJs7ELFVLu2lt6NTlBZEz9moA0b4KHEMhnMeq3GvgAE7ZDzCsdyC1BayIaGZOhMtwvtDZgXz8g==",
       "dev": true,
       "requires": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/signaling": "^1.4.3"
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/messaging": "^1.10.0",
+        "@lumino/signaling": "^1.10.0"
       }
     },
     "@jupyterlab/services": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.0.5.tgz",
-      "integrity": "sha512-hOD9qOqDthpKmlkUoUV+1bj7Uxbe7Pe6nQbftgwfX1rXLgIJjNHkiCce2fkIiSqQh/dd3SFcu3MouTpJ6plglw==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-6.4.5.tgz",
+      "integrity": "sha512-/qE5VuA10l5C9CKYvZ9pPsmKEpGFR9p74yrC84B2cK2ErF+SPw+dHGAEilGPBco9tUWE4i4C1mtJhtxn7U9zeg==",
       "dev": true,
       "requires": {
-        "@jupyterlab/coreutils": "^5.0.3",
-        "@jupyterlab/nbformat": "^3.0.3",
-        "@jupyterlab/observables": "^4.0.3",
-        "@jupyterlab/settingregistry": "^3.0.3",
-        "@jupyterlab/statedb": "^3.0.3",
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/polling": "^1.3.3",
-        "@lumino/signaling": "^1.4.3",
+        "@jupyterlab/coreutils": "^5.4.5",
+        "@jupyterlab/nbformat": "^3.4.5",
+        "@jupyterlab/observables": "^4.4.5",
+        "@jupyterlab/settingregistry": "^3.4.5",
+        "@jupyterlab/statedb": "^3.4.5",
+        "@lumino/algorithm": "^1.9.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/polling": "^1.9.0",
+        "@lumino/signaling": "^1.10.0",
         "node-fetch": "^2.6.0",
-        "ws": "^7.2.0"
+        "ws": "^7.4.6"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "dev": true
+        }
       }
     },
     "@jupyterlab/settingregistry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.0.3.tgz",
-      "integrity": "sha512-mxvP4AMi62u6ekarhgCefJeyTV6Z8fnnKb0psvvnWikdSgQT6x7OngV5emuo2N02IXkUqXxM1aHRwYQsLUAbOQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-3.4.5.tgz",
+      "integrity": "sha512-7TzNT4OQjKPGQnsSZpzR2A4AUOnyUBulcBi6lUrxdWASDTPvh85oMH8nrf++ZIGYv8oX2Ot1rNG+VXRyFiKSKw==",
       "dev": true,
       "requires": {
-        "@jupyterlab/statedb": "^3.0.3",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3",
+        "@jupyterlab/statedb": "^3.4.5",
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/signaling": "^1.10.0",
         "ajv": "^6.12.3",
         "json5": "^2.1.1"
       }
     },
     "@jupyterlab/statedb": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.0.3.tgz",
-      "integrity": "sha512-j+WtWyLszzmlsLEkcEhbc+TAMdc+6X+CCeBSFgOK9GN9RSp+pe9tGU/Y4PS0xPSvUwLSqv7RG0Oj0+/1bmNwlw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.4.5.tgz",
+      "integrity": "sha512-WeLFCV5EsIxggYhdzbS+VJ0Lh8DjfQY5/QCBg5LoGMcTR7I3+aOXbFOBz/YKd1ZOhUnTtItVyDav4JreEpBhmg==",
       "dev": true,
       "requires": {
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/properties": "^1.2.3",
-        "@lumino/signaling": "^1.4.3"
+        "@lumino/commands": "^1.19.0",
+        "@lumino/coreutils": "^1.11.0",
+        "@lumino/disposable": "^1.10.0",
+        "@lumino/properties": "^1.8.0",
+        "@lumino/signaling": "^1.10.0"
       }
     },
     "@lumino/algorithm": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.3.3.tgz",
-      "integrity": "sha512-I2BkssbOSLq3rDjgAC3fzf/zAIwkRUnAh60MO0lYcaFdSGyI15w4K3gwZHGIO0p9cKEiNHLXKEODGmOjMLOQ3g==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.9.2.tgz",
+      "integrity": "sha512-Z06lp/yuhz8CtIir3PNTGnuk7909eXt4ukJsCzChsGuot2l5Fbs96RJ/FOHgwCedaX74CtxPjXHXoszFbUA+4A==",
       "dev": true
     },
     "@lumino/collections": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.3.3.tgz",
-      "integrity": "sha512-vN3GSV5INkgM6tMLd+WqTgaPnQNTY7L/aFUtTOC8TJQm+vg1eSmR4fNXsoGHM3uA85ctSJThvdZr5triu1Iajg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.9.2.tgz",
+      "integrity": "sha512-j8eLf9m9cX4pc4yPld3oDfRwJIwI/T1h0/RJUsIyCF74qNQ8W7OH2V49PF6ARUqL7ug4Gltp9y2t6V9B9SOxDA==",
       "dev": true,
       "requires": {
-        "@lumino/algorithm": "^1.3.3"
+        "@lumino/algorithm": "^1.9.2"
       }
     },
     "@lumino/commands": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.12.0.tgz",
-      "integrity": "sha512-5TFlhDzZk1X8rCBjhh0HH3j6CcJ03mx2Pd/1rGa7MB5R+3+yYYk+gTlfHRqsxdehNRmiISaHRSrMnW8bynW7ZQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.20.1.tgz",
+      "integrity": "sha512-7u0vc3qWVAyI3CHGmQ+MXP5bvmj5dtnU5J4u2aRrodtlysU3nLjGhD57bbTq2VUqpmS1bkfBqNFhO1e4PFKSaQ==",
       "dev": true,
       "requires": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/domutils": "^1.2.3",
-        "@lumino/keyboard": "^1.2.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.8.0"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.2",
+        "@lumino/domutils": "^1.8.2",
+        "@lumino/keyboard": "^1.8.2",
+        "@lumino/signaling": "^1.10.2",
+        "@lumino/virtualdom": "^1.14.2"
       }
     },
     "@lumino/coreutils": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.5.3.tgz",
-      "integrity": "sha512-G72jJ6sgOwAUuilz+cri7LpHIJxllK+qz+YZUC3fyyWHK7oRlZemcc43jZAVE+tagTdMxKYSQWNIVzM5lI8sWw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.12.1.tgz",
+      "integrity": "sha512-JLu3nTHzJk9N8ohZ85u75YxemMrmDzJdNgZztfP7F7T7mxND3YVNCkJG35a6aJ7edu1sIgCjBxOvV+hv27iYvQ==",
       "dev": true
     },
     "@lumino/disposable": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.4.3.tgz",
-      "integrity": "sha512-zKQ9N2AEGcYpG6PJkeMWQXvoXU9w1ocji78z+fboM/SmSgtOIVGeQt3fZeldymf0XrlOPpNXs1ZFg54yWUMnXA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.10.2.tgz",
+      "integrity": "sha512-jwt8bCw3OU65wJMOCJUZAfVVUdxZdEufRDrDkoG91aSW+/R/VBzt33AqZX81/B0KxddL6R3PdNWI+0fRJBaeYw==",
       "dev": true,
       "requires": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/signaling": "^1.4.3"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/signaling": "^1.10.2"
       }
     },
     "@lumino/domutils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.2.3.tgz",
-      "integrity": "sha512-SEi8WZSy+DWMkL5CfAY78MHbi3x83AVmRFxjs9+A6qsFPde+Hr1I4DNtLsSDmfAWsobHHgBnjyNp2ZkQEq0IEA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.8.2.tgz",
+      "integrity": "sha512-QIpMfkPJrs4GrWBuJf2Sn1fpyVPmvqUUAeD8xAQo8+4V5JAT0vUDLxZ9HijefMgNCi3+Bs8Z3lQwRCrz+cFP1A==",
       "dev": true
     },
     "@lumino/dragdrop": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.7.1.tgz",
-      "integrity": "sha512-IeSSOTmpqBSWz+EVsbGVeHe/KIaHaUsQXZ4BJCEbCKgNGHbqMfUOtlneiKq7rEhZGF4wYs7gWWjNhMVZbUGO9Q==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.14.1.tgz",
+      "integrity": "sha512-SeciSUHKBBkkMKqK0l20c7vwGQA7pu/jMFMBK75In2Oz0049qU0OyNk6ngpcKRSBC/VKsbTPBQGI673w7Bd/VQ==",
       "dev": true,
       "requires": {
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3"
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.2"
       }
     },
     "@lumino/keyboard": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.2.3.tgz",
-      "integrity": "sha512-ibS0sz0VABeuJXx2JVSz36sUBMUOcQNCNPybVhwzN/GkJFs0dnDKluMu+3Px0tkB2y33bGPZU/RLZY1Xj/faEA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.8.2.tgz",
+      "integrity": "sha512-Dy+XqQ1wXbcnuYtjys5A0pAqf4SpAFl9NY6owyIhXAo0Va7w3LYp3jgiP1xAaBAwMuUppiUAfrbjrysZuZ625g==",
       "dev": true
     },
     "@lumino/messaging": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.4.3.tgz",
-      "integrity": "sha512-wa2Pj2KOuLNLS2n0wVBzUVFGbvjL1FLbuCOAUEYfN6xXVleqqtGGzd08uTF7ebu01KCO3VQ38+dkvoaM/C2qPw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.10.2.tgz",
+      "integrity": "sha512-mVC3E5sptkU8g8GLNGiu4f1iY15QjU6R8RP9rJD6X8i2UAnT7z8KT+9rB3m7l8UqH1Pw5DZo8IJznrp6J/Dvmw==",
       "dev": true,
       "requires": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/collections": "^1.3.3"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/collections": "^1.9.2"
       }
     },
     "@lumino/polling": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-1.3.3.tgz",
-      "integrity": "sha512-uMRi6sPRnKW8m38WUY3qox1jxwzpvceafUbDJATCwyrZ48+YoY5Fxfmd9dqwioHS1aq9np5c6L35a9ZGuS0Maw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-1.11.1.tgz",
+      "integrity": "sha512-SS60bhdUfwUAIPk0fc39bhBA0MjQ3Zqt/yBi6Jwzjkpm70y50J0GBW5/Ia6FZIQ2ht8cAQXuLCVAqYgQTCVuGw==",
       "dev": true,
       "requires": {
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3"
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.2",
+        "@lumino/signaling": "^1.10.2"
       }
     },
     "@lumino/properties": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.2.3.tgz",
-      "integrity": "sha512-dbS9V/L+RpQoRjxHMAGh1JYoXaLA6F7xkVbg/vmYXqdXZ7DguO5C3Qteu9tNp7Z7Q31TqFWUCrniTI9UJiJCoQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.8.2.tgz",
+      "integrity": "sha512-EkjI9Cw8R0U+xC9HxdFSu7X1tz1H1vKu20cGvJ2gU+CXlMB1DvoYJCYxCThByHZ+kURTAap4SE5x8HvKwNPbig==",
       "dev": true
     },
     "@lumino/signaling": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.4.3.tgz",
-      "integrity": "sha512-6clc8SMcH0tyKXIX31xw6sxjxJl5hj4YRd1DTHTS62cegQ0FkO8JjJeuv+Nc1pgTg6nEAf65aSOHpUdsFHDAvQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.10.2.tgz",
+      "integrity": "sha512-LvnLRb2ngOZbRtFHRcKkMdPSXm0bzfVv/5mbx/hpT1DWHihMtBpGQ+bIfFvnARmFJoI11Wt+DMX77MWPw6tpig==",
       "dev": true,
       "requires": {
-        "@lumino/algorithm": "^1.3.3"
+        "@lumino/algorithm": "^1.9.2"
       }
     },
     "@lumino/virtualdom": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.8.0.tgz",
-      "integrity": "sha512-X/1b8b7TxB9tb4+xQiS8oArcA/AK7NBZrsg2dzu/gHa3JC45R8nzQ+0tObD8Nd0gF/e9w9Ps9M62rLfefcbbKw==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.14.2.tgz",
+      "integrity": "sha512-iF20v6s4gP/hAH4VjmBtv2dexr18W4vL/Y5Rx4+U3kS/ZIFU7987NsM+0Yr6W9kdBQ1w6+pJjRBS9sWYnohdoQ==",
       "dev": true,
       "requires": {
-        "@lumino/algorithm": "^1.3.3"
+        "@lumino/algorithm": "^1.9.2"
       }
     },
     "@lumino/widgets": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.19.0.tgz",
-      "integrity": "sha512-LR1mwbbTS0K58K3SzC7TtapjSDBwL75Udrif9vBygyIpYNTT9VfRFvl+PT2+KSwhefClNI4n5pZ2s+RO908rsg==",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.34.0.tgz",
+      "integrity": "sha512-HvvZ/UL1mcbvZ2IZrIA5p+YVSjTzQYrkXwPkFDPs6TgSgj5VmBm8Y13B7gS+/p9634OR5WNiWVO3KNALVHRXcw==",
       "dev": true,
       "requires": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/commands": "^1.12.0",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/domutils": "^1.2.3",
-        "@lumino/dragdrop": "^1.7.1",
-        "@lumino/keyboard": "^1.2.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/properties": "^1.2.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.8.0"
+        "@lumino/algorithm": "^1.9.2",
+        "@lumino/commands": "^1.20.1",
+        "@lumino/coreutils": "^1.12.1",
+        "@lumino/disposable": "^1.10.2",
+        "@lumino/domutils": "^1.8.2",
+        "@lumino/dragdrop": "^1.14.1",
+        "@lumino/keyboard": "^1.8.2",
+        "@lumino/messaging": "^1.10.2",
+        "@lumino/properties": "^1.8.2",
+        "@lumino/signaling": "^1.10.2",
+        "@lumino/virtualdom": "^1.14.2"
       }
     },
     "@nodelib/fs.scandir": {
@@ -1984,6 +1934,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/backbone": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.14.tgz",
+      "integrity": "sha512-85ldQ99fiYTJFBlZuAJRaCdvTZKZ2p1fSs3fVf+6Ub6k1X0g0hNJ0qJ/2FOByyyAQYLtbEz3shX5taKQfBKBDw==",
+      "dev": true,
+      "requires": {
+        "@types/jquery": "*",
+        "@types/underscore": "*"
+      }
+    },
     "@types/component-emitter": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
@@ -2046,9 +2006,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.5.tgz",
-      "integrity": "sha512-6RXU9Xzpc6vxNrS6FPPapN1SxSHgQ336WC6Jj/N8q30OiaBZ00l1GBgeP7usjVZPivSkGUfL1z/WW6TX989M+w==",
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"
@@ -2085,9 +2045,9 @@
       "dev": true
     },
     "@types/sizzle": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -2097,9 +2057,9 @@
       "dev": true
     },
     "@types/underscore": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.0.tgz",
-      "integrity": "sha512-ipNAQLgRnG0EWN1cTtfdVHp5AyTW/PAMJ1PxLN4bAKSHbusSZbj48mIHiydQpN7GgQrYqwfnvZ573OVfJm5Nzg==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.4.tgz",
+      "integrity": "sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg==",
       "dev": true
     },
     "@types/yargs": {
@@ -3423,15 +3383,15 @@
       }
     },
     "d3-color": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
-      "integrity": "sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "dev": true
     },
     "d3-format": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.0.1.tgz",
-      "integrity": "sha512-hdL7+HBIohpgfolhBxr1KX47VMD6+vVD/oEFrxk5yhmzV2prk99EkFKYpXuhVkFpTgHdJ6/4bYcjdLPPXV4tIA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "dev": true
     },
     "data-urls": {
@@ -3656,10 +3616,27 @@
         "void-elements": "^2.0.0"
       }
     },
+    "dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      }
+    },
     "domain-browser": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
       "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
+      "dev": true
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true
     },
     "domexception": {
@@ -3677,6 +3654,26 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "ee-first": {
@@ -3778,6 +3775,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "dev": true
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true
     },
     "es-abstract": {
@@ -5276,6 +5279,18 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
     },
     "http-errors": {
       "version": "1.7.2",
@@ -9099,9 +9114,9 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true
     },
     "ms": {
@@ -9168,10 +9183,37 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -9198,9 +9240,9 @@
       "dev": true
     },
     "nouislider": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.2.0.tgz",
-      "integrity": "sha512-LoZwN+wwU+z/0/UtjQY8VUcVElFJX6GfHkgJ5z1NIt/+KpOsjxEW4EAtBkBWvHNxf9HBzR62K6ft9NpNBkA5/w==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-15.4.0.tgz",
+      "integrity": "sha512-AV7UMhGhZ4Mj6ToMT812Ib8OJ4tAXR2/Um7C4l4ZvvsqujF0WpQTpqqHJ+9xt4174R7ueQOUrBR4yakJpAIPCA==",
       "dev": true
     },
     "npm-run-path": {
@@ -9430,6 +9472,12 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "dev": true
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -9497,6 +9545,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -9526,6 +9580,25 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postcss": {
+      "version": "8.4.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+          "dev": true
+        }
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -10146,6 +10219,34 @@
         }
       }
     },
+    "sanitize-html": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.1.tgz",
+      "integrity": "sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
+        }
+      }
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -10486,6 +10587,12 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
     "source-map-resolve": {
@@ -11177,9 +11284,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "test": "npm run test:jest && npm run test:karma && npm run test:prettier"
   },
   "devDependencies": {
-    "@jupyter-widgets/base": "^5.0.0-alpha.3",
-    "@jupyter-widgets/base-manager": "1.0.0-alpha.2",
-    "@jupyter-widgets/controls": "^4.0.0-alpha.3",
+    "@jupyter-widgets/base": "^6.0.0",
+    "@jupyter-widgets/base-manager": "^1.0.0",
+    "@jupyter-widgets/controls": "^5.0.0",
     "@trivago/prettier-plugin-sort-imports": "^2.0.4",
     "@types/jest": "^26.0.24",
     "@types/mocha": "^9.0.0",

--- a/test/manager.spec.js
+++ b/test/manager.spec.js
@@ -80,18 +80,16 @@ describe('widget manager', () => {
     expect(leaflet).toBeInstanceOf(HTMLDivElement);
   });
 
-  it('throws for invalid specs', async () => {
+  it('shows error widget for invalid specs', async () => {
     const provider = new FakeState({
       123: {
         state: {},
       },
     });
-    const oldHandler = window.onerror;
-    window.onerror = () => {};
     const manager = createWidgetManager(provider);
-    await expectAsync(manager.render('123', container)).toBeRejected();
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    window.onerror = oldHandler;
+    await manager.render('123', container);
+    const errorWidget = container.querySelector('.jupyter-widgets-error-widget');
+    expect(errorWidget).toBeInstanceOf(HTMLDivElement);
   });
 
   it('has proper lifecycle events', async () => {


### PR DESCRIPTION
Properly supports `ipywidgets=8.0.0` by building against [`@jupyter-widgets/base==6.0.0`](https://www.npmjs.com/package/@jupyter-widgets/base) and [`@jupyter-widgets/controls==5.0.0`](https://www.npmjs.com/package/@jupyter-widgets/controls). These are the latest versions of each package.

